### PR TITLE
Performance Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Each of these is optional (or can be present multiple times), depending on how y
 - `gamerule advance_time` must be set to `false` for some effects to work properly, and the time to be set at 10000. This limitation should be removed when the pack will be upgraded to Minecraft 26.1.
 - Whatever is described in the [Kits module Readme](data/sgp.kits/README.md)
 - Whatever is described in the [Cosmetics module Readme](data/sgp.cosmetics/README.md)
+- You should forceload all the chunks in which you placed markers.
 
 # Uninstallation
 

--- a/data/minecraft/function/even_tick_functions.mcfunction
+++ b/data/minecraft/function/even_tick_functions.mcfunction
@@ -2,12 +2,6 @@
 # 
 # Executes functions one game tick out of 2 
 
-execute as @e[type=marker,tag=sgp.marker,name="lieu"] at @s \
-        run function sgp.world:lieu/lieu_trouve with entity @s data
-
-execute as @e[type=marker,tag=sgp.marker,name="pvp_arena",limit=1] at @s \
-        run function sgp.misc:players_in_game with entity @s data
-
 execute if score #events_mineurs_actifs sgp.dummy matches 1 \
         run function sgp.mineurs:misc/check_if_players
 

--- a/data/minecraft/function/execute_repeating_functions.mcfunction
+++ b/data/minecraft/function/execute_repeating_functions.mcfunction
@@ -22,7 +22,7 @@ execute as @a[tag=sgp.in_game,scores={sgp.death_reset_tags=1..}] \
     if entity @a[predicate=sgp.majeurs:hide_and_seek/ongoing] \
         run function sgp.majeurs:hide_and_seek/delay_death
 
-execute if entity @e[tag=sgp.marker,name="playable_map_model",type=marker] \
+execute if score #diorama_enabled sgp.dummy matches 1 \
     run function sgp.misc:player_mannequins/tick
 
 execute as @a[tag=sgp.in_game,scores={sgp.death_reset_tags=1..}] run \
@@ -67,14 +67,10 @@ function sgp.kits:abilities/tick
 # ---------- MISCELLANEOUS ----------
 function sgp.misc:kill_counter
 
-execute as @e[type=marker,tag=sgp.marker,name="teleporter"] at @s \
-    run function sgp.world:teleporter/run
-
 execute if score #reflexes_ticks sgp.timer matches 1..99 \
     run function sgp.mineurs:reflexes/running
 
 function sgp.misc:128_ticks_functions
-
 
 execute as @a[tag=sgp.in_game,tag=!sgp.climbing,predicate=sgp.world:is_climbing] \
     run function sgp.world:climbing_boost/add
@@ -88,10 +84,13 @@ execute as @a[tag=sgp.sliding_up,predicate=!sgp.world:is_pressing_jump_next_to_h
 
 execute as @a[scores={sgp.share_item=1..}] run function sgp.mineurs:lootdrop/show_item/main
 
-execute as @e[tag=sgp.marker,name="Lootdrop",tag=!sgp.opened_chest,type=marker] at @s \
-    if block ~ ~ ~ trapped_chest \
-    unless data block ~ ~ ~ LootTable \
-        run data modify block ~ ~ ~ LootTable set value "sgp.misc:empty"
+function sgp.misc:players_in_game/macro with storage sgp:data markers_lists.pvp_arena[0]
+
+function sgp.misc:loop_as_entity/init {list_location:"markers_lists.lootdrop", command:"if block ~ ~ ~ trapped_chest run data modify block ~ ~ ~ LootTable set value 'sgp.misc:empty'"}
+
+function sgp.misc:loop_as_entity/init {list_location:"markers_lists.location", command:"run function sgp.world:lieu/lieu_trouve with entity @s data"}
+
+function sgp.misc:loop_as_entity/init {list_location:"markers_lists.teleporter", command:"run function sgp.world:teleporter/run"}
 
 
 

--- a/data/sgp.kits/function/abilities/illusions/apply_offset.mcfunction
+++ b/data/sgp.kits/function/abilities/illusions/apply_offset.mcfunction
@@ -13,6 +13,6 @@ execute if entity @s[tag=sgp.direction_right] run function sgp.kits:abilities/il
 function #bs.position:add_pos {scale:0.001}
 
 # Update the illusions' pose
-execute if score #pose sgp.dummy matches 1 unless data entity @s {pose:"crouching"} run return run data modify entity @s pose set value "crouching"
-execute if score #pose sgp.dummy matches 2 unless data entity @s {pose:"swimming"} run return run data modify entity @s pose set value "swimming"
-execute if score #pose sgp.dummy matches 0 unless data entity @s {pose:"standing"} run return run data modify entity @s pose set value "standing"
+execute if score #pose sgp.dummy matches 1 run return run data modify entity @s pose set value "crouching"
+execute if score #pose sgp.dummy matches 2 run return run data modify entity @s pose set value "swimming"
+execute if score #pose sgp.dummy matches 0 run return run data modify entity @s pose set value "standing"

--- a/data/sgp.kits/function/abilities/rays/tick.mcfunction
+++ b/data/sgp.kits/function/abilities/rays/tick.mcfunction
@@ -38,7 +38,9 @@ scoreboard players operation @e[tag=sgp.predictor,limit=1,type=marker] bs.pos.z 
 # Use Bookshelf to offset the marker by those delta scores
 execute as @e[tag=sgp.predictor,limit=1,type=marker] run function #bs.position:add_pos {scale:0.001}
 
-function #bs.link:as_children {run:"function sgp.kits:abilities/rays/tick_children"}
+# Don't directly use `#bs.link:as_children`, as the @e is too expensive without the type
+scoreboard players operation $link.to bs.in = @s bs.id
+execute as @e[predicate=bs.link:link_equal,limit=8,type=item_display] run function sgp.kits:abilities/rays/tick_children
 
 playsound entity.ender_eye.death master @a ~ ~ ~ 1 0
 

--- a/data/sgp.kits/function/unlocking/check_kit_unlock.mcfunction
+++ b/data/sgp.kits/function/unlocking/check_kit_unlock.mcfunction
@@ -12,4 +12,4 @@ execute as @a[scores={sgp.cancer_found=2}] run function sgp.kits:unlocking/unloc
 execute as @a[scores={sgp.enderman_found=2}] run function sgp.kits:unlocking/unlocking_kit {kit:enderman, kit_color:dark_purple, fw_color:"8073150"}
 execute as @a[scores={sgp.alchimiste_found=2}] run function sgp.kits:unlocking/unlocking_kit {kit:alchimiste, kit_color:light_purple, fw_color:"12801229"}
 
-execute as @e[type=marker,tag=sgp.marker,name="kit_unlock"] at @s run function sgp.kits:unlocking/enable_kit_unlock with entity @s data
+function sgp.misc:loop_as_entity/init {list_location:"markers_lists.kit_unlock", command:"run function sgp.kits:unlocking/enable_kit_unlock with entity @s data"}

--- a/data/sgp.misc/function/128_ticks_functions.mcfunction
+++ b/data/sgp.misc/function/128_ticks_functions.mcfunction
@@ -19,6 +19,4 @@ execute store result score #nbr_lieu sgp.lieu_count \
 execute at @e[type=marker,tag=sgp.marker,name="respawn",limit=1] \
     run spawnpoint @a ~ ~ ~ ~ ~
 
-function sgp.misc:player_mannequins/init_markers_pos
-
 scoreboard players set #128_ticks_clock sgp.dummy 0

--- a/data/sgp.misc/function/initialization.mcfunction
+++ b/data/sgp.misc/function/initialization.mcfunction
@@ -264,3 +264,39 @@ data merge storage sgp:kits {\
     }
 
 data modify storage sgp.text prefix set value {text:"[", color:gray, extra:[{text:"SGP", color:gold}, {text:"] "}]}
+
+data modify storage sgp:data const.hex set value ["0","1","2","3","4","5","6","7","8","9","a","b","c","d","e","f"]
+
+
+
+# ---------- Enable and init Diorama ----------
+
+scoreboard players set #diorama_enabled sgp.dummy 0
+execute if entity @e[tag=sgp.marker,name="playable_map_model",limit=1,type=marker] \
+    run scoreboard players set #diorama_enabled sgp.dummy 1
+
+function sgp.misc:player_mannequins/init_markers_pos
+
+
+
+# ---------- Init marker uuids ----------
+
+data remove storage sgp:data markers_lists.lootdrop
+execute as @e[tag=sgp.marker,name="Lootdrop",type=marker] \
+    run function sgp.misc:uuid_array_to_string/init {list_location:"markers_lists.lootdrop"}
+
+data remove storage sgp:data markers_lists.kit_unlock
+execute as @e[tag=sgp.marker,name="kit_unlock",type=marker] \
+    run function sgp.misc:uuid_array_to_string/init {list_location:"markers_lists.kit_unlock"}
+
+data remove storage sgp:data markers_lists.location
+execute as @e[tag=sgp.marker,name="lieu",type=marker] \
+    run function sgp.misc:uuid_array_to_string/init {list_location:"markers_lists.location"}
+    
+data remove storage sgp:data markers_lists.pvp_arena
+execute as @e[tag=sgp.marker,name="pvp_arena",limit=1,type=marker] \
+    run function sgp.misc:uuid_array_to_string/init {list_location:"markers_lists.pvp_arena"}
+
+data remove storage sgp:data markers_lists.teleporter
+execute as @e[tag=sgp.marker,name="teleporter",type=marker] \
+    run function sgp.misc:uuid_array_to_string/init {list_location:"markers_lists.teleporter"}

--- a/data/sgp.misc/function/loop_as_entity/init.mcfunction
+++ b/data/sgp.misc/function/loop_as_entity/init.mcfunction
@@ -1,0 +1,15 @@
+#> sgp.misc:loop_as_entity/init
+# `{list_location: nbt path, command: string}`
+
+# 1. Copy the full list to a temporary array
+$data modify storage sgp:data temp.loop_list set from storage sgp:data $(list_location)
+
+# 2. Save the command globally so it persists across recursion steps
+$data modify storage sgp:data temp.current_command set value "$(command)"
+
+# 3. If the list isn't empty, prepare the arguments for the first run (merging uuid and command)
+data modify storage sgp:data temp.run_args set from storage sgp:data temp.loop_list[0]
+data modify storage sgp:data temp.run_args.command set from storage sgp:data temp.current_command
+
+# 4. Start the loop
+function sgp.misc:loop_as_entity/recursion with storage sgp:data temp.run_args

--- a/data/sgp.misc/function/loop_as_entity/recursion.mcfunction
+++ b/data/sgp.misc/function/loop_as_entity/recursion.mcfunction
@@ -1,0 +1,15 @@
+#> function sgp.misc:loop_as_entity/recursion
+# `{uuid: entity uuid, command: "run kill @s"}`
+
+# 1. Run the dynamic command directly as the entity!
+$execute as $(uuid) at @s $(command)
+
+# 2. Remove the processed element (Index 1 becomes the new Index 0)
+data remove storage sgp:data temp.loop_list[0]
+
+# 3. If there is still at least one element, prepare the arguments for the next run and recurse
+execute unless data storage sgp:data temp.loop_list[0] run return 1
+
+data modify storage sgp:data temp.run_args set from storage sgp:data temp.loop_list[0]
+data modify storage sgp:data temp.run_args.command set from storage sgp:data temp.current_command
+function sgp.misc:loop_as_entity/recursion with storage sgp:data temp.run_args

--- a/data/sgp.misc/function/player_mannequins/apply_mannequin_pos.mcfunction
+++ b/data/sgp.misc/function/player_mannequins/apply_mannequin_pos.mcfunction
@@ -15,6 +15,6 @@ function #bs.position:set_rot {scale:0.001}
 # Reset the mannequins' timeout
 function #bs.health:time_to_live {with:{time:5,unit:"s",on_death:"execute on passengers run kill @s"}}
 
-execute if score #pose sgp.dummy matches 1 unless data entity @s {pose:"crouching"} run return run data modify entity @s pose set value "crouching"
-execute if score #pose sgp.dummy matches 2 unless data entity @s {pose:"swimming"} run return run data modify entity @s pose set value "swimming"
-execute if score #pose sgp.dummy matches 0 unless data entity @s {pose:"standing"} run return run data modify entity @s pose set value "standing"
+execute if score #pose sgp.dummy matches 1 run return run data modify entity @s pose set value "crouching"
+execute if score #pose sgp.dummy matches 2 run return run data modify entity @s pose set value "swimming"
+execute if score #pose sgp.dummy matches 0 run return run data modify entity @s pose set value "standing"

--- a/data/sgp.misc/function/player_mannequins/check_for_giant_player.mcfunction
+++ b/data/sgp.misc/function/player_mannequins/check_for_giant_player.mcfunction
@@ -10,4 +10,5 @@ $execute positioned ~-3 ~-3 ~-3 as @a[dx=$(mdx_plus_6),dy=$(mdy_plus_6),dz=$(mdz
 
 execute as @a[tag=sgp.has_giant_mannequin,tag=!sgp.around_model] run function sgp.misc:player_mannequins/disappear {type:"giant"}
 
-execute as @a[tag=sgp.around_model,tag=!sgp.has_giant_mannequin] run function sgp.misc:player_mannequins/on_player_around_model
+execute as @a[tag=sgp.around_model,tag=!sgp.has_giant_mannequin] \
+    run function sgp.misc:player_mannequins/on_player_around_model with storage sgp:data markers_lists.playable_map[0]

--- a/data/sgp.misc/function/player_mannequins/check_for_spawned_player.mcfunction
+++ b/data/sgp.misc/function/player_mannequins/check_for_spawned_player.mcfunction
@@ -10,4 +10,4 @@ $execute as @a[tag=sgp.has_small_mannequin] unless entity @s[dx=$(dx),dy=$(dy),d
 
 # Detects if a player just entered bounds
 $execute as @a[tag=sgp.in_game,tag=!sgp.has_small_mannequin,dx=$(dx),dy=$(dy),dz=$(dz)] \
-    run function sgp.misc:player_mannequins/on_player_spawn
+    run function sgp.misc:player_mannequins/on_player_spawn with storage sgp:data markers_lists.playable_map_model[0]

--- a/data/sgp.misc/function/player_mannequins/init_markers_pos.mcfunction
+++ b/data/sgp.misc/function/player_mannequins/init_markers_pos.mcfunction
@@ -1,16 +1,28 @@
 #> sgp.misc:player_mannequins/init_markers_pos
 
+# --- Fetch the miniature map's origin ---
+execute as @e[tag=sgp.marker,name=playable_map_model,limit=1,type=marker] at @s run function #bs.position:get_pos {scale:1000}
+execute as @e[tag=sgp.marker,name=playable_map_model,limit=1,type=marker] run scoreboard players operation #model_x sgp.dummy = @s bs.pos.x
+execute as @e[tag=sgp.marker,name=playable_map_model,limit=1,type=marker] run scoreboard players operation #model_y sgp.dummy = @s bs.pos.y
+execute as @e[tag=sgp.marker,name=playable_map_model,limit=1,type=marker] run scoreboard players operation #model_z sgp.dummy = @s bs.pos.z
+
+# Empty the list of markers
+data remove storage sgp:data markers_lists.playable_map_model
+
+# Get UUID to be able to run as this marker every tick without having to resolve @e every time.
+execute as @e[tag=sgp.marker,name=playable_map_model,limit=1,type=marker] \
+    run function sgp.misc:uuid_array_to_string/init {list_location:"markers_lists.playable_map_model"}
+
 # --- Fetch the original map's origin ---
 execute as @e[tag=sgp.marker,name=playable_map,limit=1,type=marker] at @s run function #bs.position:get_pos {scale:1000}
 execute as @e[tag=sgp.marker,name=playable_map,limit=1,type=marker] run scoreboard players operation #map_x sgp.dummy = @s bs.pos.x
 execute as @e[tag=sgp.marker,name=playable_map,limit=1,type=marker] run scoreboard players operation #map_y sgp.dummy = @s bs.pos.y
 execute as @e[tag=sgp.marker,name=playable_map,limit=1,type=marker] run scoreboard players operation #map_z sgp.dummy = @s bs.pos.z
 
-# --- Fetch the miniature map's origin ---
-execute as @e[tag=sgp.marker,name=playable_map_model,limit=1,type=marker] at @s run function #bs.position:get_pos {scale:1000}
-execute as @e[tag=sgp.marker,name=playable_map_model,limit=1,type=marker] run scoreboard players operation #model_x sgp.dummy = @s bs.pos.x
-execute as @e[tag=sgp.marker,name=playable_map_model,limit=1,type=marker] run scoreboard players operation #model_y sgp.dummy = @s bs.pos.y
-execute as @e[tag=sgp.marker,name=playable_map_model,limit=1,type=marker] run scoreboard players operation #model_z sgp.dummy = @s bs.pos.z
+
+data remove storage sgp:data markers_lists.playable_map
+execute as @e[tag=sgp.marker,name=playable_map,limit=1,type=marker] \
+    run function sgp.misc:uuid_array_to_string/init {list_location:"markers_lists.playable_map"}
 
 # --- Fetch Map Dimensions from the marker data ---
 execute as @e[tag=sgp.marker,name=playable_map,limit=1,type=marker] store result score #map_dx sgp.dummy run data get entity @s data.dx

--- a/data/sgp.misc/function/player_mannequins/on_player_around_model.mcfunction
+++ b/data/sgp.misc/function/player_mannequins/on_player_around_model.mcfunction
@@ -1,8 +1,9 @@
 #> sgp.misc:player_mannequins/on_player_around_model
+# `{uuid: playable_map marker uuid}`
 
 tag @s add sgp.has_giant_mannequin
 
 data modify storage sgp:data misc.player_mannequins.current_uuid set from entity @s UUID
 data modify storage sgp:data misc.player_mannequins.type set value "giant"
 data modify storage sgp:data misc.player_mannequins.size set value "16"
-execute at @e[tag=sgp.marker,name=playable_map,type=marker] run function sgp.misc:player_mannequins/summon with storage sgp:data misc.player_mannequins
+$execute at $(uuid) run function sgp.misc:player_mannequins/summon with storage sgp:data misc.player_mannequins

--- a/data/sgp.misc/function/player_mannequins/on_player_spawn.mcfunction
+++ b/data/sgp.misc/function/player_mannequins/on_player_spawn.mcfunction
@@ -1,8 +1,9 @@
 #> sgp.misc:player_mannequins/on_player_spawn
+# `{uuid: playable_map_model marker uuid}`
 
 tag @s add sgp.has_small_mannequin
 
 data modify storage sgp:data misc.player_mannequins.current_uuid set from entity @s UUID
 data modify storage sgp:data misc.player_mannequins.type set value "small"
 data modify storage sgp:data misc.player_mannequins.size set value "0.0625"
-execute at @e[tag=sgp.marker,name=playable_map_model,type=marker] run function sgp.misc:player_mannequins/summon with storage sgp:data misc.player_mannequins
+$execute at $(uuid) run function sgp.misc:player_mannequins/summon with storage sgp:data misc.player_mannequins

--- a/data/sgp.misc/function/player_mannequins/tick.mcfunction
+++ b/data/sgp.misc/function/player_mannequins/tick.mcfunction
@@ -1,10 +1,5 @@
 #> sgp.misc:player_mannequins/tick
+# `{model_marker_uuid,map_marker_uuid: uuids of the markers}`
 
-execute as @e[tag=sgp.marker,name="playable_map",limit=1,type=marker] at @s \
-    run function sgp.misc:player_mannequins/check_for_spawned_player with entity @s data
-
-execute as @e[tag=sgp.marker,name="playable_map_model",limit=1,type=marker] at @s \
-    run function sgp.misc:player_mannequins/check_for_giant_player with entity @s data
-
-execute as @a[tag=sgp.has_small_mannequin] at @s run function sgp.misc:player_mannequins/update_small_pos
-execute as @a[tag=sgp.has_giant_mannequin] at @s run function sgp.misc:player_mannequins/update_giant_pos
+function sgp.misc:player_mannequins/tick_small with storage sgp:data markers_lists.playable_map[0]
+function sgp.misc:player_mannequins/tick_giant with storage sgp:data markers_lists.playable_map_model[0]

--- a/data/sgp.misc/function/player_mannequins/tick_giant.mcfunction
+++ b/data/sgp.misc/function/player_mannequins/tick_giant.mcfunction
@@ -1,0 +1,7 @@
+#> sgp.misc:player_mannequins/tick_giant
+# `{uuid: playable_map_model marker uuid}`
+
+$execute as $(uuid) at @s \
+    run function sgp.misc:player_mannequins/check_for_giant_player with entity @s data
+
+execute as @a[tag=sgp.has_giant_mannequin] at @s run function sgp.misc:player_mannequins/update_giant_pos

--- a/data/sgp.misc/function/player_mannequins/tick_small.mcfunction
+++ b/data/sgp.misc/function/player_mannequins/tick_small.mcfunction
@@ -1,0 +1,6 @@
+#> sgp.misc:player_mannequins/tick_small
+# `{uuid: playable_map marker uuid}`
+
+$execute as $(uuid) at @s \
+    run function sgp.misc:player_mannequins/check_for_spawned_player with entity @s data
+execute as @a[tag=sgp.has_small_mannequin] at @s run function sgp.misc:player_mannequins/update_small_pos

--- a/data/sgp.misc/function/player_mannequins/update_giant_pos.mcfunction
+++ b/data/sgp.misc/function/player_mannequins/update_giant_pos.mcfunction
@@ -1,8 +1,7 @@
 #> sgp.misc:player_mannequins/update_giant_pos
 
 # Grab the player's exact position and rotation
-function #bs.position:get_pos {scale:1000}
-function #bs.position:get_rot {scale:1000}
+function #bs.position:get_pos_and_rot {scale:1000}
 
 # Subtract the miniature map's origin to get the relative offset
 scoreboard players operation @s bs.pos.x -= #model_x sgp.dummy
@@ -67,4 +66,6 @@ scoreboard players set #pose sgp.dummy 0
 execute if predicate sgp.misc:is_sneaking run scoreboard players set #pose sgp.dummy 1
 execute if predicate sgp.misc:is_swimming run scoreboard players set #pose sgp.dummy 2
 
-function #bs.link:as_children {run:"execute if entity @s[tag=sgp.giant_mannequin,type=mannequin] run function sgp.misc:player_mannequins/apply_mannequin_pos"}
+# Don't directly use `#bs.link:as_children`, as the @e is too expensive without the type
+scoreboard players operation $link.to bs.in = @s bs.id
+execute as @e[predicate=bs.link:link_equal,tag=sgp.giant_mannequin,type=mannequin] run function sgp.misc:player_mannequins/apply_mannequin_pos

--- a/data/sgp.misc/function/player_mannequins/update_small_pos.mcfunction
+++ b/data/sgp.misc/function/player_mannequins/update_small_pos.mcfunction
@@ -2,8 +2,7 @@
 
 # Grab the player's exact position and rotation
 # We scale by 1000 (milliblocks/millidegrees) to prevent the division by 16 from wiping out fractional precision!
-function #bs.position:get_pos {scale:1000}
-function #bs.position:get_rot {scale:1000}
+function #bs.position:get_pos_and_rot {scale:1000}
 
 # Subtract the original map's origin to get the player's relative offset inside the maze
 scoreboard players operation @s bs.pos.x -= #map_x sgp.dummy
@@ -32,4 +31,6 @@ scoreboard players set #pose sgp.dummy 0
 execute if predicate sgp.misc:is_sneaking run scoreboard players set #pose sgp.dummy 1
 execute if predicate sgp.misc:is_swimming run scoreboard players set #pose sgp.dummy 2
 
-function #bs.link:as_children {run:"execute if entity @s[tag=sgp.small_mannequin,type=mannequin] run function sgp.misc:player_mannequins/apply_mannequin_pos"}
+# Don't directly use `#bs.link:as_children`, as the @e is too expensive without the type
+scoreboard players operation $link.to bs.in = @s bs.id
+execute as @e[predicate=bs.link:link_equal,tag=sgp.small_mannequin,type=mannequin] run function sgp.misc:player_mannequins/apply_mannequin_pos

--- a/data/sgp.misc/function/players_in_game/check.mcfunction
+++ b/data/sgp.misc/function/players_in_game/check.mcfunction
@@ -1,4 +1,4 @@
-#> sgp.misc:players_in_game
+#> sgp.misc:players_in_game/check
 # `{radius: int}`
 #
 # Players who are inside the radius have a tag, others don't

--- a/data/sgp.misc/function/players_in_game/macro.mcfunction
+++ b/data/sgp.misc/function/players_in_game/macro.mcfunction
@@ -1,0 +1,5 @@
+#> sgp.misc:players_in_game/macro
+# `{uuid: pvp_arena marker uuid}`
+
+$execute as $(uuid) at @s \
+        run function sgp.misc:players_in_game/check with entity @s data

--- a/data/sgp.misc/function/uuid_array_to_string/concat.mcfunction
+++ b/data/sgp.misc/function/uuid_array_to_string/concat.mcfunction
@@ -1,0 +1,2 @@
+# Prepend the new character to the front of the string
+$data modify storage sgp:data temp.string set value "$(char)$(string)"

--- a/data/sgp.misc/function/uuid_array_to_string/extract_digit.mcfunction
+++ b/data/sgp.misc/function/uuid_array_to_string/extract_digit.mcfunction
@@ -1,0 +1,21 @@
+# Insert the standard UUID hyphens at the correct character marks
+execute if score #global_digit_index sgp.dummy matches 12 run function sgp.misc:uuid_array_to_string/insert_hyphen
+execute if score #global_digit_index sgp.dummy matches 16 run function sgp.misc:uuid_array_to_string/insert_hyphen
+execute if score #global_digit_index sgp.dummy matches 20 run function sgp.misc:uuid_array_to_string/insert_hyphen
+execute if score #global_digit_index sgp.dummy matches 24 run function sgp.misc:uuid_array_to_string/insert_hyphen
+
+# Modulo by 16 to get the lowest digit
+scoreboard players operation #digit sgp.dummy = #current sgp.dummy
+scoreboard players operation #digit sgp.dummy %= 16 sgp.dummy
+
+# Restore the missing 32nd bit (add 8) if this is the final digit of a negative number
+execute if score #digit_index sgp.dummy matches 7 if score #is_negative sgp.dummy matches 1 run scoreboard players add #digit sgp.dummy 8
+
+# Store the digit (0-15) and trigger the lookup macro
+execute store result storage sgp:data temp.macro_input.digit int 1 run scoreboard players get #digit sgp.dummy
+function sgp.misc:uuid_array_to_string/get_char with storage sgp:data temp.macro_input
+
+# Divide by 16 to shift to the next digit, and increment our loop counters
+scoreboard players operation #current sgp.dummy /= 16 sgp.dummy
+scoreboard players add #digit_index sgp.dummy 1
+scoreboard players add #global_digit_index sgp.dummy 1

--- a/data/sgp.misc/function/uuid_array_to_string/get_char.mcfunction
+++ b/data/sgp.misc/function/uuid_array_to_string/get_char.mcfunction
@@ -1,0 +1,6 @@
+# Grab the correct letter/number from our constant array
+$data modify storage sgp:data temp.macro_input.char set from storage sgp:data const.hex[$(digit)]
+
+# Copy the running string into the macro input so we can prepend to it
+data modify storage sgp:data temp.macro_input.string set from storage sgp:data temp.string
+function sgp.misc:uuid_array_to_string/concat with storage sgp:data temp.macro_input

--- a/data/sgp.misc/function/uuid_array_to_string/init.mcfunction
+++ b/data/sgp.misc/function/uuid_array_to_string/init.mcfunction
@@ -1,0 +1,26 @@
+#> sgp.misc:uuid_array_to_string/init
+# `{list_location: nbt path}`
+#
+# Convert the UUID array of the entity into its string version, and store it
+
+# Reset the string and global digit counter
+data modify storage sgp:data temp.string set value ""
+scoreboard players set #global_digit_index sgp.dummy 0
+
+# Process the 4 integers from right to left (int3 -> int2 -> int1 -> int0)
+execute store result score #current sgp.dummy run data get entity @s UUID[3]
+function sgp.misc:uuid_array_to_string/process_int
+
+execute store result score #current sgp.dummy run data get entity @s UUID[2]
+function sgp.misc:uuid_array_to_string/process_int
+
+execute store result score #current sgp.dummy run data get entity @s UUID[1]
+function sgp.misc:uuid_array_to_string/process_int
+
+execute store result score #current sgp.dummy run data get entity @s UUID[0]
+function sgp.misc:uuid_array_to_string/process_int
+
+data modify storage sgp:data temp.obj.uuid set from storage sgp:data temp.string
+
+# Store the finished string at the specified location
+$data modify storage sgp:data $(list_location) append from storage sgp:data temp.obj

--- a/data/sgp.misc/function/uuid_array_to_string/insert_hyphen.mcfunction
+++ b/data/sgp.misc/function/uuid_array_to_string/insert_hyphen.mcfunction
@@ -1,0 +1,8 @@
+# Set the character to a hyphen
+data modify storage sgp:data temp.macro_input.char set value "-"
+
+# Copy the current string state into the macro input
+data modify storage sgp:data temp.macro_input.string set from storage sgp:data temp.string
+
+# Run the concatenation
+function sgp.misc:uuid_array_to_string/concat with storage sgp:data temp.macro_input

--- a/data/sgp.misc/function/uuid_array_to_string/process_int.mcfunction
+++ b/data/sgp.misc/function/uuid_array_to_string/process_int.mcfunction
@@ -1,0 +1,17 @@
+scoreboard players set #digit_index sgp.dummy 0
+scoreboard players set #is_negative sgp.dummy 0
+
+# The Overflow Trick: Flip negative numbers to positive 31-bit integers
+execute if score #current sgp.dummy matches ..-1 run scoreboard players set #is_negative sgp.dummy 1
+execute if score #is_negative sgp.dummy matches 1 run scoreboard players add #current sgp.dummy 2147483647
+execute if score #is_negative sgp.dummy matches 1 run scoreboard players add #current sgp.dummy 1
+
+# Extract the 8 hex characters for this integer
+function sgp.misc:uuid_array_to_string/extract_digit
+function sgp.misc:uuid_array_to_string/extract_digit
+function sgp.misc:uuid_array_to_string/extract_digit
+function sgp.misc:uuid_array_to_string/extract_digit
+function sgp.misc:uuid_array_to_string/extract_digit
+function sgp.misc:uuid_array_to_string/extract_digit
+function sgp.misc:uuid_array_to_string/extract_digit
+function sgp.misc:uuid_array_to_string/extract_digit

--- a/data/sgp.world/function/teleporter/teleported.mcfunction
+++ b/data/sgp.world/function/teleporter/teleported.mcfunction
@@ -4,4 +4,4 @@
 # Teleports the player and do additional effects
 
 $execute as @a[tag=sgp.to_teleport,scores={sgp.teleporteur=60}] run tp @s $(x) $(y) $(z) $(yaw) $(pitch)
-execute as @a[tag=sgp.to_teleport,scores={sgp.teleporteur=60}] run execute at @s run particle minecraft:reverse_portal ~ ~1 ~ 0 0 0 1 200 normal
+execute as @a[tag=sgp.to_teleport,scores={sgp.teleporteur=60}] at @s run particle minecraft:reverse_portal ~ ~1 ~ 0 0 0 1 200 normal


### PR DESCRIPTION
* Use uuids directly instead of selectors, for markers that need to be checked every tick, and don't change over time

* don't check for data that is modified, as /data modify does it natively

* don't use #bs.link:as_children as it basically checks for @e[is_children], without a type  (obviously)

* init diorama marker's positions once at the beginning

* get_pos_and_rot instead of get_pos and get_rot successively